### PR TITLE
Add missing ComponentTypeName to control definitions

### DIFF
--- a/src/Atata/Components/Fields/DateInput`1.cs
+++ b/src/Atata/Components/Fields/DateInput`1.cs
@@ -9,7 +9,7 @@ namespace Atata
     /// Handles any <c>input</c> element with <c>type="date"</c>, <c>type="text"</c> or without the defined <c>type</c> attribute.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='text' or @type='date' or not(@type)]")]
+    [ControlDefinition("input[@type='text' or @type='date' or not(@type)]", ComponentTypeName = "date input")]
     [Format("d")]
     public class DateInput<TOwner> : Input<DateTime?, TOwner>
         where TOwner : PageObject<TOwner>

--- a/src/Atata/Components/Fields/EmailInput`1.cs
+++ b/src/Atata/Components/Fields/EmailInput`1.cs
@@ -5,7 +5,7 @@
     /// Default search is performed by the label.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='email']")]
+    [ControlDefinition("input[@type='email']", ComponentTypeName = "email input")]
     public class EmailInput<TOwner> : Input<string, TOwner>
         where TOwner : PageObject<TOwner>
     {

--- a/src/Atata/Components/Fields/FileInput`1.cs
+++ b/src/Atata/Components/Fields/FileInput`1.cs
@@ -7,7 +7,7 @@ namespace Atata
     /// Default search is performed by the label.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='file']", Visibility = Visibility.Any)]
+    [ControlDefinition("input[@type='file']", Visibility = Visibility.Any, ComponentTypeName = "file input")]
     public class FileInput<TOwner> : Input<string, TOwner>
         where TOwner : PageObject<TOwner>
     {

--- a/src/Atata/Components/Fields/HiddenInput`2.cs
+++ b/src/Atata/Components/Fields/HiddenInput`2.cs
@@ -6,7 +6,7 @@
     /// </summary>
     /// <typeparam name="T">The type of the control's data.</typeparam>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='hidden']", Visibility = Visibility.Hidden)]
+    [ControlDefinition("input[@type='hidden']", Visibility = Visibility.Hidden, ComponentTypeName = "hidden input")]
     [FindFirst]
     public class HiddenInput<T, TOwner> : Input<T, TOwner>
         where TOwner : PageObject<TOwner>

--- a/src/Atata/Components/Fields/Input`2.cs
+++ b/src/Atata/Components/Fields/Input`2.cs
@@ -8,7 +8,7 @@ namespace Atata
     /// </summary>
     /// <typeparam name="T">The type of the control's data.</typeparam>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type!='button' and @type!='submit' and @type!='reset']")]
+    [ControlDefinition("input[@type!='button' and @type!='submit' and @type!='reset']", ComponentTypeName = "input")]
     [FindByLabel]
     public class Input<T, TOwner> : EditableField<T, TOwner>
         where TOwner : PageObject<TOwner>

--- a/src/Atata/Components/Fields/NumberInput`1.cs
+++ b/src/Atata/Components/Fields/NumberInput`1.cs
@@ -6,7 +6,7 @@
     /// Handles any <c>&lt;input&gt;</c> element with <c>type="number"</c>, <c>type="text"</c> or without the defined <c>type</c> attribute.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='number' or @type='text' or not(@type)]")]
+    [ControlDefinition("input[@type='number' or @type='text' or not(@type)]", ComponentTypeName = "number input")]
     public class NumberInput<TOwner> : Input<decimal?, TOwner>
         where TOwner : PageObject<TOwner>
     {

--- a/src/Atata/Components/Fields/Option`2.cs
+++ b/src/Atata/Components/Fields/Option`2.cs
@@ -6,7 +6,7 @@
     /// </summary>
     /// <typeparam name="T">The type of the data.</typeparam>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("option", IgnoreNameEndings = "Option")]
+    [ControlDefinition("option", IgnoreNameEndings = "Option", ComponentTypeName = "option")]
     [FindFirst]
     public class Option<T, TOwner> : Field<T, TOwner>
         where TOwner : PageObject<TOwner>

--- a/src/Atata/Components/Fields/PasswordInput`2.cs
+++ b/src/Atata/Components/Fields/PasswordInput`2.cs
@@ -5,7 +5,7 @@
     /// Default search is performed by the label.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='password']")]
+    [ControlDefinition("input[@type='password']", ComponentTypeName = "password input")]
     public class PasswordInput<TOwner> : Input<string, TOwner>
         where TOwner : PageObject<TOwner>
     {

--- a/src/Atata/Components/Fields/RadioButtonList`2.cs
+++ b/src/Atata/Components/Fields/RadioButtonList`2.cs
@@ -16,7 +16,7 @@ namespace Atata
     /// Supports enum, string, numeric and other types.
     /// </typeparam>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='radio']", IgnoreNameEndings = "RadioButtons,RadioButtonList,Radios,RadioGroup,Buttons,ButtonList,Options,OptionGroup")]
+    [ControlDefinition("input[@type='radio']", IgnoreNameEndings = "RadioButtons,RadioButtonList,Radios,RadioGroup,Buttons,ButtonList,Options,OptionGroup", ComponentTypeName = "radio button list")]
     [FindByName]
     [FindItemByLabel]
     public class RadioButtonList<T, TOwner> : OptionList<T, TOwner>

--- a/src/Atata/Components/Fields/RadioButton`1.cs
+++ b/src/Atata/Components/Fields/RadioButton`1.cs
@@ -5,7 +5,7 @@
     /// Default search is performed by the label.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='radio']", IgnoreNameEndings = "RadioButton,Radio,Button,Option")]
+    [ControlDefinition("input[@type='radio']", IgnoreNameEndings = "RadioButton,Radio,Button,Option", ComponentTypeName = "radio button")]
     [FindByLabel]
     public class RadioButton<TOwner> : Field<bool, TOwner>, ICheckable<TOwner>
         where TOwner : PageObject<TOwner>

--- a/src/Atata/Components/Fields/SearchInput`1.cs
+++ b/src/Atata/Components/Fields/SearchInput`1.cs
@@ -5,7 +5,7 @@
     /// Default search is performed by the label.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='search']")]
+    [ControlDefinition("input[@type='search']", ComponentTypeName = "search input")]
     public class SearchInput<TOwner> : Input<string, TOwner>
         where TOwner : PageObject<TOwner>
     {

--- a/src/Atata/Components/Fields/Select`2.cs
+++ b/src/Atata/Components/Fields/Select`2.cs
@@ -9,7 +9,7 @@
     /// </summary>
     /// <typeparam name="T">The type of the data.</typeparam>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("select", IgnoreNameEndings = "Select")]
+    [ControlDefinition("select", IgnoreNameEndings = "Select", ComponentTypeName = "select")]
     [FindByLabel]
     public class Select<T, TOwner> : EditableField<T, TOwner>
         where TOwner : PageObject<TOwner>

--- a/src/Atata/Components/Fields/TextArea`1.cs
+++ b/src/Atata/Components/Fields/TextArea`1.cs
@@ -7,7 +7,7 @@ namespace Atata
     /// Default search is performed by the label.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("textarea", IgnoreNameEndings = "TextArea")]
+    [ControlDefinition("textarea", IgnoreNameEndings = "TextArea", ComponentTypeName = "text area")]
     [FindByLabel]
     public class TextArea<TOwner> : EditableField<string, TOwner>
         where TOwner : PageObject<TOwner>

--- a/src/Atata/Components/Fields/TextInput`1.cs
+++ b/src/Atata/Components/Fields/TextInput`1.cs
@@ -6,7 +6,7 @@
     /// Handles any <c>&lt;input&gt;</c> element with <c>type="text"</c> or without the defined <c>type</c> attribute.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='text' or not(@type)]")]
+    [ControlDefinition("input[@type='text' or not(@type)]", ComponentTypeName = "text input")]
     public class TextInput<TOwner> : Input<string, TOwner>
         where TOwner : PageObject<TOwner>
     {

--- a/src/Atata/Components/Fields/TimeInput`1.cs
+++ b/src/Atata/Components/Fields/TimeInput`1.cs
@@ -8,7 +8,7 @@ namespace Atata
     /// Handles any <c>&lt;input&gt;</c> element with <c>type="time"</c>, <c>type="text"</c> or without the defined <c>type</c> attribute.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("input[@type='text' or @type='time' or not(@type)]")]
+    [ControlDefinition("input[@type='text' or @type='time' or not(@type)]", ComponentTypeName = "time input")]
     public class TimeInput<TOwner> : Input<TimeSpan?, TOwner>
         where TOwner : PageObject<TOwner>
     {

--- a/src/Atata/Components/Image`1.cs
+++ b/src/Atata/Components/Image`1.cs
@@ -5,7 +5,7 @@
     /// Default search finds the first occurring <c>&lt;img&gt;</c> element.
     /// </summary>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("img")]
+    [ControlDefinition("img", ComponentTypeName = "image")]
     public class Image<TOwner> : Control<TOwner>
         where TOwner : PageObject<TOwner>
     {

--- a/src/Atata/Components/Table`3.cs
+++ b/src/Atata/Components/Table`3.cs
@@ -7,7 +7,7 @@
     /// <typeparam name="THeader">The type of the table header control.</typeparam>
     /// <typeparam name="TRow">The type of the table row control.</typeparam>
     /// <typeparam name="TOwner">The type of the owner page object.</typeparam>
-    [ControlDefinition("table", IgnoreNameEndings = "Table")]
+    [ControlDefinition("table", IgnoreNameEndings = "Table", ComponentTypeName = "table")]
     public class Table<THeader, TRow, TOwner> : Control<TOwner>
         where THeader : TableHeader<TOwner>
         where TRow : TableRow<TOwner>


### PR DESCRIPTION
**Atata**
 - Add missing ComponentTypeName to control definitions:
   - DateInput
   - EmailInput
   - FileInput
   - HiddenInput
   - Input
   - NumberInput
   - Option
   - PasswordInput
   - RadioButtonList
   - RadioButton
   - SearchInput
   - Select
   - TextArea
   - TextInput
   - TimeInput
   - Image
   - Table